### PR TITLE
Improve batch modal layout and view toggling

### DIFF
--- a/static/pipeline_v2.css
+++ b/static/pipeline_v2.css
@@ -1083,9 +1083,9 @@
 .batch-modal {
     background: white;
     border-radius: 12px;
-    width: 95%;
-    max-width: 1400px;
-    height: 85%;
+    width: min(96vw, 1500px);
+    max-width: 1500px;
+    height: 90vh;
     display: flex;
     flex-direction: column;
     overflow: hidden;
@@ -1095,10 +1095,11 @@
 .batch-modal-header {
     background: linear-gradient(135deg, #3498db, #2980b9);
     color: white;
-    padding: 1.25rem 1.5rem;
+    padding: 0.75rem 1.25rem;
     display: flex;
     justify-content: space-between;
     align-items: center;
+    gap: 1rem;
 }
 
 .batch-modal-title {
@@ -1107,15 +1108,15 @@
     display: flex;
     align-items: center;
     gap: 0.75rem;
-    flex-direction: column;
-    align-items: flex-start;
+    flex-wrap: wrap;
 }
 
 .batch-header-subtitle {
-    font-size: 0.9rem;
+    font-size: 0.85rem;
     font-weight: 400;
     opacity: 0.9;
-    margin-top: 0.25rem;
+    flex-basis: 100%;
+    margin-left: 2rem;
 }
 
 .batch-modal-close {
@@ -1144,13 +1145,13 @@
 /* Batch Info Strip */
 .batch-info-strip {
     background: white;
-    padding: 1rem 1.5rem;
+    padding: 0.75rem 1.25rem;
     border-bottom: 1px solid #e9ecef;
     display: flex;
     justify-content: space-between;
     align-items: center;
     flex-wrap: wrap;
-    gap: 1rem;
+    gap: 0.75rem;
 }
 
 .batch-navigation-controls {
@@ -1223,25 +1224,28 @@
     display: flex;
     flex-direction: column;
     overflow: hidden;
+    min-height: 0;
 }
 
 .page-container {
     flex: 1;
+    min-height: 0;
     display: flex;
     flex-direction: column;
     align-items: center;
-    justify-content: center;
-    padding: 1.5rem;
-    overflow: auto;
+    justify-content: flex-start;
+    padding: 1rem;
+    gap: 0.75rem;
 }
 
 .page-image-wrapper {
-    max-height: 70vh;
-    max-width: 100%;
+    flex: 1;
+    min-height: 0;
+    width: 100%;
     display: flex;
     align-items: center;
     justify-content: center;
-    margin-bottom: 1rem;
+    padding: 0.5rem;
 }
 
 .current-page-image {
@@ -1265,7 +1269,7 @@
 .thumbnail-slider-container {
     background: white;
     border-top: 1px solid #e9ecef;
-    padding: 1rem;
+    padding: 0.75rem 1rem;
 }
 
 .thumbnail-slider {
@@ -1340,8 +1344,9 @@
 /* Grid View */
 .batch-grid-view {
     flex: 1;
-    padding: 1.5rem;
+    padding: 1rem;
     overflow-y: auto;
+    min-height: 0;
 }
 
 .batch-pages-grid {

--- a/templates/pipeline_v2.html
+++ b/templates/pipeline_v2.html
@@ -1762,7 +1762,7 @@ function setBatchView(viewType) {
     
     // Show/hide appropriate view
     if (viewType === 'single') {
-        if (singleView) singleView.style.display = 'block';
+        if (singleView) singleView.style.display = 'flex';
         if (gridView) gridView.style.display = 'none';
     } else if (viewType === 'grid') {
         if (singleView) singleView.style.display = 'none';


### PR DESCRIPTION
## Summary
- reduce the batch modal header footprint and tighten surrounding spacing so more room is available for page previews
- adjust the single-page view layout to better use the available height and avoid oversized documents after toggling views
- ensure the single view restores its flex layout when re-selected for consistent interaction

## Testing
- pytest *(fails: interactive tests prompt for input under pytest capture)*

------
https://chatgpt.com/codex/tasks/task_e_68d3bb63136c83278aaa455e9e9f916c