### PR TITLE
Add multimodal chunking stage with context management

### DIFF
--- a/main.py
+++ b/main.py
@@ -364,7 +364,10 @@ async def get_page_preview_api(
 async def submit_pipeline_task(
     file: UploadFile = File(...),
     batch_size: int = Form(4),
-    overlap_pages: int = Form(0)
+    overlap_pages: int = Form(0),
+    prompt: Optional[str] = Form(None),
+    model: Optional[str] = Form(None),
+    temperature: Optional[float] = Form(None)
 ):
     """Submit a file for pipeline processing"""
     try:
@@ -388,13 +391,19 @@ async def submit_pipeline_task(
         task_id = processing_manager.submit_task(
             file_path=temp_path,
             source_type="upload",
-            config=config
+            config=config,
+            prompt=prompt,
+            model=model,
+            temperature=temperature
         )
 
         return JSONResponse(content={
             "task_id": task_id,
             "filename": file.filename,
-            "config": config.to_dict()
+            "config": config.to_dict(),
+            "prompt": prompt,
+            "model": model,
+            "temperature": temperature
         })
 
     except Exception as e:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ Pillow==10.1.0
 boto3==1.34.0
 python-dotenv==1.0.0
 pydantic==2.5.0
+requests==2.31.0

--- a/src/models/batch_models.py
+++ b/src/models/batch_models.py
@@ -36,6 +36,10 @@ class PageBatch:
     processed_at: Optional[datetime] = None
     error_message: Optional[str] = None
     processing_time: Optional[float] = None
+    lmm_output: Optional[str] = None
+    chunk_summary: List[str] = field(default_factory=list)
+    context_snapshot: Dict[str, Any] = field(default_factory=dict)
+    prompt_used: Optional[str] = None
 
     def __post_init__(self):
         if not self.batch_id:
@@ -63,7 +67,11 @@ class PageBatch:
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "processed_at": self.processed_at.isoformat() if self.processed_at else None,
             "error_message": self.error_message,
-            "processing_time": self.processing_time
+            "processing_time": self.processing_time,
+            "lmm_output": self.lmm_output,
+            "chunk_summary": self.chunk_summary,
+            "context_snapshot": self.context_snapshot,
+            "prompt_used": self.prompt_used
         }
 
 @dataclass
@@ -101,6 +109,10 @@ class ProcessingTask:
     completed_at: Optional[datetime] = None
     error_message: Optional[str] = None
     batches: List[PageBatch] = field(default_factory=list)
+    prompt: Optional[str] = None
+    model: Optional[str] = None
+    temperature: float = 0.1
+    context_state: Dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self):
         if not self.task_id:
@@ -147,7 +159,11 @@ class ProcessingTask:
                 "metadata": self.document.metadata
             },
             "config": self.config.to_dict(),
-            "batches": [batch.to_dict() for batch in self.batches]
+            "batches": [batch.to_dict() for batch in self.batches],
+            "prompt": self.prompt,
+            "model": self.model,
+            "temperature": self.temperature,
+            "context_state": self.context_state
         }
 
 @dataclass

--- a/src/processors/__init__.py
+++ b/src/processors/__init__.py
@@ -1,5 +1,7 @@
 from .pdf_processor import PDFProcessor
 from .pdf_splitter import PDFSplitter
 from .processing_manager import ProcessingManager
+from .lmm_processor import LMMProcessor
+from .context_manager import ContextManager
 
-__all__ = ['PDFProcessor', 'PDFSplitter', 'ProcessingManager']
+__all__ = ['PDFProcessor', 'PDFSplitter', 'ProcessingManager', 'LMMProcessor', 'ContextManager']

--- a/src/processors/context_manager.py
+++ b/src/processors/context_manager.py
@@ -1,0 +1,110 @@
+"""Utility for maintaining multimodal chunking context across batches."""
+
+from __future__ import annotations
+
+import copy
+import threading
+from typing import Dict, List, Optional, Any
+
+
+class ContextManager:
+    """Track contextual state for each document across batches.
+
+    The context object exposed to the LMM aligns with the structure defined in the
+    product specification::
+
+        context = {
+            "last_chunks": [...],
+            "heading_hierarchy": {
+                "level1": "Document Title",
+                "level2": "Section",
+                "level3": "Subsection"
+            },
+            "continuation_metadata": {...}
+        }
+
+    A dedicated context is maintained per document identifier to support parallel
+    processing.
+    """
+
+    def __init__(self) -> None:
+        self._contexts: Dict[str, Dict[str, Any]] = {}
+        self._lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # Context lifecycle helpers
+    # ------------------------------------------------------------------
+    def _empty_context(self) -> Dict[str, Any]:
+        return {
+            "last_chunks": [],
+            "heading_hierarchy": {},
+            "continuation_metadata": {}
+        }
+
+    def reset_context(self, document_id: str) -> None:
+        """Reset stored context for a document."""
+
+        with self._lock:
+            self._contexts[document_id] = self._empty_context()
+
+    def drop_context(self, document_id: str) -> None:
+        """Remove all stored information for a document."""
+
+        with self._lock:
+            self._contexts.pop(document_id, None)
+
+    # ------------------------------------------------------------------
+    # Context accessors
+    # ------------------------------------------------------------------
+    def get_context(self, document_id: str) -> Dict[str, Any]:
+        """Return a copy of the current context for a document."""
+
+        with self._lock:
+            context = self._contexts.setdefault(document_id, self._empty_context())
+            return copy.deepcopy(context)
+
+    def build_context_payload(self, document_id: str) -> Dict[str, Any]:
+        """Return a context object ready to be injected into a prompt."""
+
+        return self.get_context(document_id)
+
+    # ------------------------------------------------------------------
+    # Context mutation helpers
+    # ------------------------------------------------------------------
+    def update_context(
+        self,
+        document_id: str,
+        *,
+        last_chunks: Optional[List[str]] = None,
+        heading_hierarchy: Optional[Dict[str, str]] = None,
+        continuation_metadata: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Merge new context details for a document.
+
+        Args:
+            document_id: Unique document identifier.
+            last_chunks: Recent chunk summaries produced by the LMM.
+            heading_hierarchy: Detected headings for the latest batch.
+            continuation_metadata: Arbitrary metadata describing continuation
+                requirements for the next batch.
+
+        Returns:
+            Updated context dictionary.
+        """
+
+        with self._lock:
+            context = self._contexts.setdefault(document_id, self._empty_context())
+
+            if last_chunks is not None:
+                context["last_chunks"] = last_chunks
+
+            if heading_hierarchy is not None:
+                context["heading_hierarchy"] = heading_hierarchy
+
+            if continuation_metadata is not None:
+                context["continuation_metadata"] = continuation_metadata
+
+            return copy.deepcopy(context)
+
+
+__all__ = ["ContextManager"]

--- a/src/processors/lmm_processor.py
+++ b/src/processors/lmm_processor.py
@@ -1,0 +1,376 @@
+"""Large Multimodal Model (LMM) processor for batch chunking."""
+
+from __future__ import annotations
+
+import base64
+import io
+import json
+import logging
+import os
+import time
+from typing import Any, Dict, List, Optional
+
+import requests
+
+from ..models.batch_models import PageBatch
+
+logger = logging.getLogger(__name__)
+
+
+class LMMProcessor:
+    """Interface with the OpenRouter API to process page batches."""
+
+    DEFAULT_MODEL = "google/gemini-2.5-pro-exp"
+
+    def __init__(
+        self,
+        *,
+        api_key: Optional[str] = None,
+        base_url: str = "https://openrouter.ai/api/v1/chat/completions",
+        temperature: float = 0.1,
+        max_retries: int = 3,
+        timeout: int = 60,
+        default_prompt: Optional[str] = None,
+    ) -> None:
+        self.api_key = api_key or os.getenv("OPENROUTER_API_KEY")
+        self.base_url = base_url
+        self.temperature = temperature
+        self.max_retries = max_retries
+        self.timeout = timeout
+        self.default_prompt = default_prompt or (
+            "You are a meticulous chunking assistant. Break the provided document "
+            "pages into semantically coherent chunks, returning well formatted "
+            "markdown with headings and short summaries for each chunk."
+        )
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def process_batch(
+        self,
+        batch: PageBatch,
+        *,
+        context: Dict[str, Any],
+        prompt: Optional[str] = None,
+        model: Optional[str] = None,
+        temperature: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        """Process a single batch of pages with the LMM."""
+
+        model_to_use = model or self.DEFAULT_MODEL
+        prompt_to_use = prompt.strip() if prompt else self.default_prompt
+        temperature_to_use = temperature if temperature is not None else self.temperature
+
+        payload = self._build_payload(
+            batch,
+            context=context,
+            prompt=prompt_to_use,
+            model=model_to_use,
+            temperature=temperature_to_use,
+        )
+
+        start_time = time.time()
+
+        if not self.api_key:
+            logger.warning(
+                "OPENROUTER_API_KEY not set. Falling back to mock LMM output for batch %s.",
+                batch.batch_id,
+            )
+            raw_output = self._build_mock_output(batch, prompt_to_use, context)
+        else:
+            response_json = self._send_request(payload)
+            raw_output = self._extract_output(response_json)
+
+        processing_time = time.time() - start_time
+
+        parsed_chunks = self._parse_chunks(raw_output)
+        heading_hierarchy = self._derive_heading_hierarchy(raw_output)
+        continuation_metadata = self._derive_continuation_metadata(parsed_chunks, raw_output)
+        last_chunks = parsed_chunks[-2:] if parsed_chunks else []
+
+        context_snapshot = {
+            "previous_context": context,
+            "last_chunks": last_chunks,
+            "heading_hierarchy": heading_hierarchy,
+            "continuation_metadata": continuation_metadata,
+        }
+
+        return {
+            "raw_output": raw_output,
+            "chunks": parsed_chunks,
+            "heading_hierarchy": heading_hierarchy,
+            "continuation_metadata": continuation_metadata,
+            "last_chunks": last_chunks,
+            "context": context_snapshot,
+            "prompt_used": prompt_to_use,
+            "model": model_to_use,
+            "processing_time": processing_time,
+        }
+
+    # ------------------------------------------------------------------
+    # Payload preparation helpers
+    # ------------------------------------------------------------------
+    def _build_payload(
+        self,
+        batch: PageBatch,
+        *,
+        context: Dict[str, Any],
+        prompt: str,
+        model: str,
+        temperature: float,
+    ) -> Dict[str, Any]:
+        message_context = self._format_context_for_prompt(context)
+        batch_metadata = self._format_batch_metadata(batch)
+        images = self._prepare_image_payloads(batch)
+
+        user_text = (
+            "## Chunking Instructions\n"
+            "You will receive consecutive PDF page images. "
+            "Apply the provided prompt to segment the content into high quality "
+            "chunks with headings, summaries, and any relevant metadata."
+            "\n\n"
+            f"### User Prompt\n{prompt}\n\n"
+            f"### Batch Metadata\n{batch_metadata}\n\n"
+            f"### Previous Context\n{message_context}\n\n"
+            "Return the response in markdown. Use the following guidelines:\n"
+            "- Mark each chunk with a level-3 heading (###).\n"
+            "- Provide a one sentence summary and bullet highlights when relevant.\n"
+            "- Note if the chunk continues into the next batch."
+        )
+
+        user_content: List[Dict[str, Any]] = [{"type": "text", "text": user_text}]
+        if images:
+            user_content.extend(images)
+        else:
+            user_content.append(
+                {
+                    "type": "text",
+                    "text": "[Image content unavailable – proceed using prior context only]",
+                }
+            )
+
+        payload = {
+            "model": model,
+            "temperature": temperature,
+            "messages": [
+                {
+                    "role": "system",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": (
+                                "You are a large multimodal model specialised in PDF chunking. "
+                                "Preserve document structure, keep headings accurate, and "
+                                "annotate continuation requirements clearly."
+                            ),
+                        }
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": user_content,
+                },
+            ],
+        }
+
+        return payload
+
+    def _prepare_image_payloads(self, batch: PageBatch) -> List[Dict[str, Any]]:
+        images: List[Dict[str, Any]] = []
+
+        for page in batch.pages:
+            if not page.image:
+                continue
+
+            buffer = io.BytesIO()
+            page.image.save(buffer, format="PNG")
+            encoded = base64.b64encode(buffer.getvalue()).decode("utf-8")
+            data_url = f"data:image/png;base64,{encoded}"
+            images.append(
+                {
+                    "type": "image_url",
+                    "image_url": {"url": data_url},
+                }
+            )
+
+        return images
+
+    def _format_batch_metadata(self, batch: PageBatch) -> str:
+        return (
+            f"Batch ID: {batch.batch_id}\n"
+            f"Batch Number: {batch.batch_number}\n"
+            f"Page Range: {batch.start_page}-{batch.end_page}\n"
+            f"Page Count: {batch.page_count}"
+        )
+
+    def _format_context_for_prompt(self, context: Dict[str, Any]) -> str:
+        if not context:
+            return "No previous context provided."
+
+        parts: List[str] = []
+
+        last_chunks = context.get("last_chunks") or []
+        if last_chunks:
+            chunks_text = "\n".join(f"- {chunk}" for chunk in last_chunks)
+            parts.append(f"Recent chunks:\n{chunks_text}")
+
+        heading_hierarchy = context.get("heading_hierarchy") or {}
+        if heading_hierarchy:
+            headings_text = "\n".join(
+                f"  {level}: {title}" for level, title in heading_hierarchy.items()
+            )
+            parts.append(f"Heading hierarchy:\n{headings_text}")
+
+        continuation_metadata = context.get("continuation_metadata") or {}
+        if continuation_metadata:
+            continuation_text = json.dumps(continuation_metadata, indent=2)
+            parts.append(f"Continuation metadata:\n{continuation_text}")
+
+        return "\n\n".join(parts) if parts else "No previous context provided."
+
+    # ------------------------------------------------------------------
+    # Network helpers
+    # ------------------------------------------------------------------
+    def _send_request(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+        for attempt in range(1, self.max_retries + 1):
+            response = requests.post(
+                self.base_url,
+                headers=headers,
+                json=payload,
+                timeout=self.timeout,
+            )
+
+            if response.status_code == 429:
+                wait_time = min(2 ** attempt, 10)
+                logger.warning(
+                    "Rate limited by OpenRouter (attempt %s/%s). Retrying in %ss.",
+                    attempt,
+                    self.max_retries,
+                    wait_time,
+                )
+                time.sleep(wait_time)
+                continue
+
+            if response.status_code >= 400:
+                raise RuntimeError(
+                    f"OpenRouter API error {response.status_code}: {response.text}"
+                )
+
+            return response.json()
+
+        raise RuntimeError("Exceeded maximum retries when calling OpenRouter API")
+
+    def _extract_output(self, response_json: Dict[str, Any]) -> str:
+        choices = response_json.get("choices") or []
+        if not choices:
+            raise ValueError("No choices returned from LMM response")
+
+        message = choices[0].get("message", {})
+        content = message.get("content")
+
+        if isinstance(content, list):
+            text_parts = [
+                part.get("text", "")
+                for part in content
+                if isinstance(part, dict) and part.get("type") == "text"
+            ]
+            return "\n".join(part for part in text_parts if part).strip()
+
+        if isinstance(content, str):
+            return content.strip()
+
+        return ""
+
+    # ------------------------------------------------------------------
+    # Parsing helpers
+    # ------------------------------------------------------------------
+    def _parse_chunks(self, text: str) -> List[str]:
+        if not text:
+            return []
+
+        chunks: List[str] = []
+        current: List[str] = []
+
+        for line in text.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("###") or stripped.lower().startswith("chunk"):
+                if current:
+                    chunk_text = "\n".join(current).strip()
+                    if chunk_text:
+                        chunks.append(chunk_text)
+                    current = []
+            current.append(line)
+
+        if current:
+            chunk_text = "\n".join(current).strip()
+            if chunk_text:
+                chunks.append(chunk_text)
+
+        if not chunks:
+            single_chunk = text.strip()
+            return [single_chunk] if single_chunk else []
+
+        return chunks
+
+    def _derive_heading_hierarchy(self, text: str) -> Dict[str, str]:
+        hierarchy: Dict[str, str] = {}
+
+        for line in text.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("# ") and "level1" not in hierarchy:
+                hierarchy["level1"] = stripped[2:].strip()
+            elif stripped.startswith("## ") and "level2" not in hierarchy:
+                hierarchy["level2"] = stripped[3:].strip()
+            elif stripped.startswith("### ") and "level3" not in hierarchy:
+                hierarchy["level3"] = stripped[4:].strip()
+
+            if len(hierarchy) == 3:
+                break
+
+        return hierarchy
+
+    def _derive_continuation_metadata(
+        self, chunks: List[str], raw_text: str
+    ) -> Dict[str, Any]:
+        continuation = {}
+        if chunks:
+            continuation["chunk_count"] = len(chunks)
+            continuation["last_chunk_length"] = len(chunks[-1])
+
+        if raw_text.strip().endswith("…") or raw_text.strip().endswith("..."):
+            continuation["continues"] = True
+
+        return continuation
+
+    # ------------------------------------------------------------------
+    # Mock helpers
+    # ------------------------------------------------------------------
+    def _build_mock_output(
+        self, batch: PageBatch, prompt: str, context: Dict[str, Any]
+    ) -> str:
+        parts = [
+            f"# Mock Chunking Output for Batch {batch.batch_number}",
+            f"Prompt Summary: {prompt[:120]}{'...' if len(prompt) > 120 else ''}",
+        ]
+
+        if context.get("heading_hierarchy"):
+            parts.append("## Estimated Heading Context")
+            for level, heading in context["heading_hierarchy"].items():
+                parts.append(f"- {level}: {heading}")
+
+        for idx, page in enumerate(batch.page_numbers, start=1):
+            parts.append(f"### Chunk {idx}: Pages {page}")
+            parts.append(
+                "This is a placeholder chunk generated because no API key was provided. "
+                "Replace with real output by configuring OPENROUTER_API_KEY."
+            )
+
+        return "\n".join(parts)
+
+
+__all__ = ["LMMProcessor"]

--- a/static/pipeline_v2.css
+++ b/static/pipeline_v2.css
@@ -1783,20 +1783,116 @@
     .batch-tabs {
         flex-wrap: wrap;
     }
-    
+
     .batch-tab {
         min-width: 120px;
         flex: 1;
     }
-    
+
     .batch-pages-grid-inline {
         grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
         gap: 1rem;
     }
-    
+
     .batch-info-bar {
         flex-direction: column;
         align-items: flex-start;
         gap: 1rem;
     }
+}
+
+/* Chunking Output Styles */
+.prompt-preview {
+    background: #ffffff;
+    border: 1px solid #ced4da;
+    border-radius: 6px;
+    padding: 0.75rem;
+    font-family: 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+    max-height: 180px;
+    overflow-y: auto;
+    white-space: pre-line;
+}
+
+.chunking-output {
+    background: #f8f9fa;
+    border-radius: 10px;
+    padding: 1.5rem;
+    border: 1px solid #e9ecef;
+}
+
+.chunking-output .accordion-item {
+    border: none;
+    border-radius: 10px;
+    margin-bottom: 0.75rem;
+    overflow: hidden;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+}
+
+.chunking-output .accordion-button {
+    font-weight: 600;
+    background: #ffffff;
+}
+
+.chunking-output .accordion-button:not(.collapsed) {
+    color: #0d6efd;
+    background: #edf4ff;
+}
+
+.chunk-output {
+    background: #1f2937;
+    color: #f8fafc;
+    padding: 1rem;
+    border-radius: 8px;
+    overflow-x: auto;
+    font-family: 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+    font-size: 0.9rem;
+    line-height: 1.5;
+    margin-bottom: 1rem;
+}
+
+.chunk-summary {
+    background: #ffffff;
+    border: 1px solid #dee2e6;
+    border-radius: 8px;
+    padding: 0.75rem 1rem;
+    margin-bottom: 1rem;
+}
+
+.chunk-summary ul {
+    margin: 0.5rem 0 0;
+    padding-left: 1.25rem;
+}
+
+.context-snapshot {
+    background: #ffffff;
+    border: 1px solid #dee2e6;
+    border-radius: 8px;
+    padding: 1rem;
+}
+
+.context-snapshot h6 {
+    font-size: 0.85rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #6c757d;
+    margin-bottom: 0.75rem;
+}
+
+.context-section + .context-section {
+    margin-top: 0.75rem;
+}
+
+.context-section ul {
+    margin: 0.35rem 0 0;
+    padding-left: 1.25rem;
+}
+
+.fullscreen-chunking .chunking-output {
+    background: transparent;
+    border: none;
+    padding: 0;
+}
+
+.fullscreen-chunking .accordion-item {
+    border-radius: 12px;
 }

--- a/templates/pipeline_v2.html
+++ b/templates/pipeline_v2.html
@@ -125,6 +125,34 @@
                             <i class="fas fa-chevron-right"></i>
                         </div>
 
+                        <div class="stage-container" data-stage="lmm_processing" onclick="selectStage('lmm_processing')">
+                            <div class="stage-icon">
+                                <i class="fas fa-robot"></i>
+                            </div>
+                            <div class="stage-info">
+                                <div class="stage-title">LMM Processing</div>
+                                <div class="stage-count" id="lmmStageCount">0</div>
+                            </div>
+                        </div>
+
+                        <div class="pipeline-arrow">
+                            <i class="fas fa-chevron-right"></i>
+                        </div>
+
+                        <div class="stage-container" data-stage="chunking" onclick="selectStage('chunking')">
+                            <div class="stage-icon">
+                                <i class="fas fa-object-group"></i>
+                            </div>
+                            <div class="stage-info">
+                                <div class="stage-title">Chunking</div>
+                                <div class="stage-count" id="chunkingStageCount">0</div>
+                            </div>
+                        </div>
+
+                        <div class="pipeline-arrow">
+                            <i class="fas fa-chevron-right"></i>
+                        </div>
+
                         <div class="stage-container" data-stage="completed" onclick="selectStage('completed')">
                             <div class="stage-icon">
                                 <i class="fas fa-check-circle"></i>
@@ -224,6 +252,32 @@
                     </div>
                 </div>
 
+                <!-- LMM Configuration -->
+                <div class="mt-4">
+                    <h6>Chunking Instructions</h6>
+                    <div class="mb-3">
+                        <label class="form-label" for="promptInput">Prompt for Chunking</label>
+                        <textarea class="form-control" id="promptInput" rows="6"
+                                  placeholder="Describe how the model should chunk the document">Use the document metadata and provided images to produce semantically meaningful chunks. Preserve heading hierarchy, add short summaries, and flag any content that continues into the next batch.</textarea>
+                        <div class="form-text">This prompt is sent along with each batch of page images.</div>
+                    </div>
+                    <div class="row g-3">
+                        <div class="col-md-8">
+                            <label class="form-label" for="modelSelect">Model</label>
+                            <select class="form-select" id="modelSelect">
+                                <option value="google/gemini-2.5-pro-exp" selected>Gemini 2.5 Pro (OpenRouter)</option>
+                                <option value="google/gemini-2.0-flash-001">Gemini 2.0 Flash (OpenRouter)</option>
+                            </select>
+                            <div class="form-text">Select a multimodal model that supports image inputs.</div>
+                        </div>
+                        <div class="col-md-4">
+                            <label class="form-label" for="temperatureInput">Temperature</label>
+                            <input type="number" class="form-control" id="temperatureInput" value="0.1" min="0" max="1" step="0.05">
+                            <div class="form-text">Lower values keep outputs more deterministic.</div>
+                        </div>
+                    </div>
+                </div>
+
                 <!-- File List -->
                 <div class="mt-4" id="fileListContainer" style="display: none;">
                     <h6>Selected Files</h6>
@@ -253,6 +307,8 @@ const STAGES = {
     upload: { title: 'Upload Queue', description: 'Documents waiting to be processed', icon: 'fas fa-upload' },
     pdf_processing: { title: 'PDF Processing', description: 'Extracting content and metadata from PDFs', icon: 'fas fa-file-pdf' },
     splitting: { title: 'Document Splitting', description: 'Creating page batches for processing', icon: 'fas fa-cut' },
+    lmm_processing: { title: 'LMM Processing', description: 'Sending page batches to the multimodal model', icon: 'fas fa-robot' },
+    chunking: { title: 'Chunking', description: 'Review chunked output and continuation context', icon: 'fas fa-object-group' },
     completed: { title: 'Completed', description: 'Successfully processed documents', icon: 'fas fa-check-circle' },
     error: { title: 'Errors', description: 'Documents that encountered processing errors', icon: 'fas fa-exclamation-triangle' }
 };
@@ -344,6 +400,11 @@ function showUploadModal() {
 async function startProcessing() {
     const batchSize = parseInt(document.getElementById('batchSize').value);
     const overlapPages = parseInt(document.getElementById('overlapPages').value);
+    const prompt = document.getElementById('promptInput').value.trim();
+    const model = document.getElementById('modelSelect').value;
+    const temperatureValue = document.getElementById('temperatureInput').value;
+    const parsedTemperature = parseFloat(temperatureValue);
+    const temperature = Number.isNaN(parsedTemperature) ? null : parsedTemperature;
     const startBtn = document.getElementById('startProcessingBtn');
 
     startBtn.disabled = true;
@@ -351,7 +412,7 @@ async function startProcessing() {
 
     try {
         for (const file of selectedFiles) {
-            await submitFile(file, batchSize, overlapPages);
+            await submitFile(file, batchSize, overlapPages, prompt, model, temperature);
         }
 
         // Reset form
@@ -374,11 +435,20 @@ async function startProcessing() {
     }
 }
 
-async function submitFile(file, batchSize, overlapPages) {
+async function submitFile(file, batchSize, overlapPages, prompt, model, temperature) {
     const formData = new FormData();
     formData.append('file', file);
     formData.append('batch_size', batchSize);
     formData.append('overlap_pages', overlapPages);
+    if (typeof prompt === 'string') {
+        formData.append('prompt', prompt);
+    }
+    if (model) {
+        formData.append('model', model);
+    }
+    if (temperature !== null && !Number.isNaN(temperature)) {
+        formData.append('temperature', temperature);
+    }
 
     const response = await fetch('/api/pipeline/submit', {
         method: 'POST',
@@ -428,7 +498,7 @@ function updateStatusCards() {
     const tasks = Object.values(allTasks);
 
     const queueCount = tasks.filter(t => t.status === 'upload').length;
-    const processingCount = tasks.filter(t => ['pdf_processing', 'splitting'].includes(t.status)).length;
+    const processingCount = tasks.filter(t => ['pdf_processing', 'splitting', 'lmm_processing', 'chunking'].includes(t.status)).length;
     const completedCount = tasks.filter(t => t.status === 'completed').length;
     const errorCount = tasks.filter(t => t.status === 'error').length;
 
@@ -446,6 +516,8 @@ function updateStageFlow() {
         upload: tasks.filter(t => t.status === 'upload').length,
         pdf_processing: tasks.filter(t => t.status === 'pdf_processing').length,
         splitting: tasks.filter(t => t.status === 'splitting').length,
+        lmm_processing: tasks.filter(t => t.status === 'lmm_processing').length,
+        chunking: tasks.filter(t => t.status === 'chunking').length,
         completed: tasks.filter(t => t.status === 'completed').length
     };
 
@@ -453,6 +525,8 @@ function updateStageFlow() {
     document.getElementById('uploadStageCount').textContent = stageCounts.upload;
     document.getElementById('processingStageCount').textContent = stageCounts.pdf_processing;
     document.getElementById('splittingStageCount').textContent = stageCounts.splitting;
+    document.getElementById('lmmStageCount').textContent = stageCounts.lmm_processing;
+    document.getElementById('chunkingStageCount').textContent = stageCounts.chunking;
     document.getElementById('completedStageCount').textContent = stageCounts.completed;
 
     // Update active state
@@ -593,8 +667,9 @@ function getCompletedStages(task) {
     const stages = [
         { id: 'summary', name: 'Summary', icon: 'fas fa-chart-bar', available: true },
         { id: 'pdf_processing', name: 'PDF Processing', icon: 'fas fa-file-pdf', available: task.status !== 'upload' },
-        { id: 'splitting', name: 'Splitting', icon: 'fas fa-cut', available: task.status === 'completed' || task.status === 'splitting' },
-        { id: 'batches', name: 'Batches', icon: 'fas fa-layer-group', available: task.batches && task.batches.length > 0 }
+        { id: 'splitting', name: 'Splitting', icon: 'fas fa-cut', available: ['splitting', 'lmm_processing', 'chunking', 'completed'].includes(task.status) },
+        { id: 'batches', name: 'Batches', icon: 'fas fa-layer-group', available: task.batches && task.batches.length > 0 },
+        { id: 'chunking', name: 'Chunk Output', icon: 'fas fa-object-group', available: task.batches && task.batches.some(batch => batch.lmm_output) }
     ];
 
     return stages.filter(stage => stage.available);
@@ -629,6 +704,8 @@ async function createStageContent(activeStage, task) {
             // Initialize the first batch after content is rendered
             setTimeout(() => initializeBatchesContent(task), 100);
             return batchesContent;
+        case 'chunking':
+            return createChunkingContent(task);
         default:
             return createSummaryContent(task);
     }
@@ -689,6 +766,32 @@ function createSummaryContent(task) {
                             <div class="info-item">
                                 <label>Source</label>
                                 <span>${escapeHtml(task.document_info?.source_type || 'upload')}</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            ` : ''}
+
+            ${(task.prompt || task.model) ? `
+                <div class="mt-4">
+                    <h6>LMM Settings</h6>
+                    <div class="row g-3">
+                        <div class="col-md-6">
+                            <div class="info-item">
+                                <label>Model</label>
+                                <span>${escapeHtml(task.model || 'google/gemini-2.5-pro-exp')}</span>
+                            </div>
+                        </div>
+                        <div class="col-md-3">
+                            <div class="info-item">
+                                <label>Temperature</label>
+                                <span>${typeof task.temperature === 'number' ? task.temperature.toFixed(2) : '0.10'}</span>
+                            </div>
+                        </div>
+                        <div class="col-12">
+                            <div class="info-item">
+                                <label>Prompt</label>
+                                <div class="prompt-preview">${task.prompt ? escapeHtml(task.prompt) : 'Default prompt applied'}</div>
                             </div>
                         </div>
                     </div>
@@ -913,6 +1016,76 @@ function createBatchesContent(task) {
     `;
 }
 
+function createChunkingContent(task) {
+    if (!task.batches || task.batches.length === 0) {
+        return `
+            <div class="text-center text-muted py-4">
+                <i class="fas fa-object-group fa-2x mb-3"></i>
+                <p>No batches available yet</p>
+            </div>
+        `;
+    }
+
+    const hasOutput = task.batches.some(batch => batch.lmm_output);
+    if (!hasOutput) {
+        return `
+            <div class="text-center text-muted py-4">
+                <i class="fas fa-robot fa-2x mb-3"></i>
+                <p>LMM processing results will appear here once available.</p>
+            </div>
+        `;
+    }
+
+    const accordionId = `chunkAccordion-${task.task_id}`;
+
+    const accordionItems = task.batches.map((batch, index) => {
+        const chunkSummary = Array.isArray(batch.chunk_summary) && batch.chunk_summary.length > 0
+            ? `<div class="chunk-summary"><strong>Chunk Highlights</strong><ul>${batch.chunk_summary.map(item => `<li>${escapeHtml(item)}</li>`).join('')}</ul></div>`
+            : '';
+
+        const contextDetails = renderContextSnapshot(batch.context_snapshot);
+
+        const lmmOutput = batch.lmm_output
+            ? `<pre class="chunk-output">${escapeHtml(batch.lmm_output)}</pre>`
+            : '<p class="text-muted mb-0">Output not available for this batch.</p>';
+
+        return `
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="chunkHeading-${batch.batch_id}">
+                    <button class="accordion-button ${index === 0 ? '' : 'collapsed'}" type="button"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#chunkCollapse-${batch.batch_id}" aria-expanded="${index === 0}"
+                            aria-controls="chunkCollapse-${batch.batch_id}">
+                        <div class="w-100 d-flex justify-content-between align-items-center">
+                            <span>Batch ${batch.batch_number} • Pages ${batch.start_page}-${batch.end_page}</span>
+                            <span class="badge bg-${getStatusClass(batch.status)}">${formatStatus(batch.status || 'completed')}</span>
+                        </div>
+                    </button>
+                </h2>
+                <div id="chunkCollapse-${batch.batch_id}" class="accordion-collapse collapse ${index === 0 ? 'show' : ''}" data-bs-parent="#${accordionId}">
+                    <div class="accordion-body">
+                        ${lmmOutput}
+                        ${chunkSummary}
+                        ${contextDetails}
+                    </div>
+                </div>
+            </div>
+        `;
+    }).join('');
+
+    return `
+        <div class="chunking-output">
+            <div class="mb-3">
+                <h6><i class="fas fa-object-group me-2"></i>Chunked Output</h6>
+                <p class="text-muted mb-0">Review the multimodal model output for each batch, including context passed to the next batch.</p>
+            </div>
+            <div class="accordion" id="${accordionId}">
+                ${accordionItems}
+            </div>
+        </div>
+    `;
+}
+
 function createPageTimeline(task) {
     if (!task.batches || task.batches.length === 0) return '';
 
@@ -1057,9 +1230,69 @@ function getFileName(task) {
 }
 
 function formatStatus(status) {
-    return status.split('_').map(word =>
+    if (!status) {
+        return 'Unknown';
+    }
+    return status.toString().split('_').map(word =>
         word.charAt(0).toUpperCase() + word.slice(1)
     ).join(' ');
+}
+
+function renderContextSnapshot(snapshot) {
+    if (!snapshot || typeof snapshot !== 'object') {
+        return '';
+    }
+
+    const previous = snapshot.previous_context || {};
+    const lastChunks = snapshot.last_chunks && snapshot.last_chunks.length > 0
+        ? snapshot.last_chunks
+        : previous.last_chunks || [];
+    const headingHierarchy = Object.keys(snapshot.heading_hierarchy || {}).length > 0
+        ? snapshot.heading_hierarchy
+        : previous.heading_hierarchy || {};
+    const continuation = Object.keys(snapshot.continuation_metadata || {}).length > 0
+        ? snapshot.continuation_metadata
+        : previous.continuation_metadata || {};
+
+    const sections = [];
+
+    if (lastChunks.length > 0) {
+        sections.push(`
+            <div class="context-section">
+                <strong>Recent Chunks</strong>
+                <ul>${lastChunks.map(item => `<li>${escapeHtml(item)}</li>`).join('')}</ul>
+            </div>
+        `);
+    }
+
+    if (Object.keys(headingHierarchy).length > 0) {
+        sections.push(`
+            <div class="context-section">
+                <strong>Heading Hierarchy</strong>
+                <ul>${Object.entries(headingHierarchy).map(([level, value]) => `<li>${escapeHtml(level)}: ${escapeHtml(value)}</li>`).join('')}</ul>
+            </div>
+        `);
+    }
+
+    if (Object.keys(continuation).length > 0) {
+        sections.push(`
+            <div class="context-section">
+                <strong>Continuation Metadata</strong>
+                <ul>${Object.entries(continuation).map(([key, value]) => `<li>${escapeHtml(key)}: ${escapeHtml(String(value))}</li>`).join('')}</ul>
+            </div>
+        `);
+    }
+
+    if (sections.length === 0) {
+        return '';
+    }
+
+    return `
+        <div class="context-snapshot mt-3">
+            <h6 class="text-muted">Context passed to next batch</h6>
+            ${sections.join('')}
+        </div>
+    `;
 }
 
 function getStatusClass(status) {
@@ -1067,6 +1300,8 @@ function getStatusClass(status) {
         upload: 'info',
         pdf_processing: 'warning',
         splitting: 'primary',
+        lmm_processing: 'secondary',
+        chunking: 'dark',
         completed: 'success',
         error: 'danger',
         pending: 'secondary'
@@ -1173,6 +1408,11 @@ function createFullscreenHTML(task) {
                                 <i class="fas fa-layer-group me-2"></i>Batches
                             </button>
                         </li>
+                        <li class="nav-item">
+                            <button class="nav-link" data-tab="chunking" onclick="switchFullscreenTab('${task.task_id}', 'chunking')">
+                                <i class="fas fa-object-group me-2"></i>Chunking
+                            </button>
+                        </li>
                     </ul>
                 </div>
                 
@@ -1242,6 +1482,9 @@ async function loadFullscreenTabContent(taskId, tabName) {
                 break;
             case 'batches':
                 content = createFullscreenBatchesContent(task, taskId);
+                break;
+            case 'chunking':
+                content = createFullscreenChunkingContent(task);
                 break;
         }
 
@@ -1514,6 +1757,14 @@ function createFullscreenBatchesContent(task, taskId) {
                     </div>
                 </div>
             `).join('')}
+        </div>
+    `;
+}
+
+function createFullscreenChunkingContent(task) {
+    return `
+        <div class="fullscreen-chunking p-3">
+            ${createChunkingContent(task)}
         </div>
     `;
 }


### PR DESCRIPTION
## Summary
- add a dedicated context manager and OpenRouter-backed LMM processor that turns page batches into chunked output while preserving heading hierarchy
- extend the processing manager, models, and API endpoint to drive the new LMM stage with configurable prompt, model, and temperature
- refresh the pipeline dashboard UI and styles to capture prompt settings and surface per-batch chunk results alongside context metadata

## Testing
- pytest *(fails: interactive tests require stdin for PDF paths)*

------
https://chatgpt.com/codex/tasks/task_e_68d4367c5854832799d64bc88f0ec57d