### PR TITLE
Make document summary card span full width

### DIFF
--- a/templates/manual_processing.html
+++ b/templates/manual_processing.html
@@ -50,7 +50,7 @@
         </div>
 
         <div class="row g-4">
-            <div class="col-lg-6 col-xl-5">
+            <div class="col-12">
                 <div class="card h-100 border-0 shadow-sm">
                     <div class="card-body">
                         <h5 class="mb-3">


### PR DESCRIPTION
## Summary
- expand the document summary card to use the full width of the review layout for a cleaner presentation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d47cc580148327af244ae306cb5e7a