### PR TITLE
Improve OpenRouter error handling and expose pipeline warnings

### DIFF
--- a/main.py
+++ b/main.py
@@ -82,6 +82,7 @@ def _build_manual_batches_payload(session: ManualSession) -> List[Dict[str, Any]
                 "status": batch_obj.status.value,
                 "processed_at": batch_obj.processed_at.isoformat() if batch_obj.processed_at else None,
                 "error_message": batch_obj.error_message,
+                "warnings": batch_obj.warnings,
             }
         )
     return payload
@@ -163,6 +164,7 @@ def _process_manual_batches_job(session_id: str, prompt_template: str) -> None:
                 batch.context_snapshot = lmm_result.get("context", {})
                 batch.prompt_used = lmm_result.get("prompt_used")
                 batch.processing_time = lmm_result.get("processing_time")
+                batch.warnings = lmm_result.get("warnings", [])
                 batch.processed_at = datetime.utcnow()
                 batch.status = BatchStatus.COMPLETED
 

--- a/src/models/batch_models.py
+++ b/src/models/batch_models.py
@@ -40,6 +40,7 @@ class PageBatch:
     chunk_summary: List[str] = field(default_factory=list)
     context_snapshot: Dict[str, Any] = field(default_factory=dict)
     prompt_used: Optional[str] = None
+    warnings: List[str] = field(default_factory=list)
 
     def __post_init__(self):
         if not self.batch_id:
@@ -71,7 +72,8 @@ class PageBatch:
             "lmm_output": self.lmm_output,
             "chunk_summary": self.chunk_summary,
             "context_snapshot": self.context_snapshot,
-            "prompt_used": self.prompt_used
+            "prompt_used": self.prompt_used,
+            "warnings": self.warnings,
         }
 
 @dataclass

--- a/src/processors/processing_manager.py
+++ b/src/processors/processing_manager.py
@@ -272,6 +272,7 @@ class ProcessingManager:
                         batch.context_snapshot = lmm_result.get("context", {})
                         batch.prompt_used = lmm_result.get("prompt_used")
                         batch.processing_time = lmm_result.get("processing_time")
+                        batch.warnings = lmm_result.get("warnings", [])
                         batch.processed_at = datetime.now()
                         batch.status = BatchStatus.COMPLETED
 

--- a/static/human_loop.js
+++ b/static/human_loop.js
@@ -36,6 +36,18 @@ document.addEventListener('DOMContentLoaded', () => {
     let processingPoller = null;
     let instructionsDirty = false;
 
+    function escapeHtml(value) {
+        if (typeof value !== 'string') {
+            value = value?.toString() ?? '';
+        }
+        return value
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
     function setStep(stepNumber) {
         currentStep = stepNumber;
         steps.forEach(step => {
@@ -206,6 +218,15 @@ document.addEventListener('DOMContentLoaded', () => {
                     errorAlert.className = 'alert alert-danger mt-3 mb-0';
                     errorAlert.textContent = batch.error_message;
                     item.appendChild(errorAlert);
+                }
+                if (Array.isArray(batch.warnings) && batch.warnings.length > 0) {
+                    const warningAlert = document.createElement('div');
+                    warningAlert.className = 'alert alert-warning mt-3 mb-0';
+                    warningAlert.innerHTML = `
+                        <strong>Heads up:</strong><br>
+                        ${batch.warnings.map(msg => `<span class="d-block">${escapeHtml(msg)}</span>`).join('')}
+                    `;
+                    item.appendChild(warningAlert);
                 }
                 processingStatusContainer.appendChild(item);
             });
@@ -486,7 +507,10 @@ document.addEventListener('DOMContentLoaded', () => {
             <tbody>
                 ${batchesList.map(batch => `
                     <tr>
-                        <td>${batch.name}</td>
+                        <td>
+                            ${escapeHtml(batch.name)}
+                            ${Array.isArray(batch.warnings) && batch.warnings.length > 0 ? '<span class="badge bg-warning text-dark ms-2">Warning</span>' : ''}
+                        </td>
                         <td>${formatStatusBadge(batch.status)}</td>
                         <td>
                             <span class="badge bg-primary">${batch.page_count} page${batch.page_count > 1 ? 's' : ''}</span><br>

--- a/static/pipeline_v2.css
+++ b/static/pipeline_v2.css
@@ -14,6 +14,24 @@
     cursor: default;
 }
 
+.status-overview-card.clickable {
+    cursor: pointer;
+}
+
+.status-overview-card.clickable[aria-disabled="true"] {
+    cursor: not-allowed;
+    opacity: 0.6;
+}
+
+.status-overview-card.clickable.selected {
+    border-color: #dc3545;
+    box-shadow: 0 4px 18px rgba(220,53,69,0.2);
+}
+
+.status-overview-card.clickable.has-count .status-count {
+    color: #dc3545;
+}
+
 .status-overview-card:hover {
     transform: translateY(-2px);
     box-shadow: 0 4px 20px rgba(0,0,0,0.12);

--- a/templates/pipeline_v2.html
+++ b/templates/pipeline_v2.html
@@ -59,7 +59,9 @@
             </div>
         </div>
         <div class="col-md-3">
-            <div class="status-overview-card error">
+            <div class="status-overview-card error clickable" id="errorStatusCard" role="button" tabindex="0"
+                 onclick="handleErrorStatusClick()"
+                 onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();handleErrorStatusClick();}">
                 <div class="status-icon">
                     <i class="fas fa-exclamation-triangle"></i>
                 </div>
@@ -319,6 +321,25 @@ document.addEventListener('DOMContentLoaded', function() {
     startStatusUpdates();
 });
 
+function handleErrorStatusClick() {
+    const errorCountEl = document.getElementById('errorCount');
+    const errorCount = errorCountEl ? parseInt(errorCountEl.textContent, 10) || 0 : 0;
+
+    if (errorCount === 0) {
+        if (typeof showAlert === 'function') {
+            showAlert('No errors to review right now.', 'info');
+        }
+        return;
+    }
+
+    selectStage('error');
+
+    const detailsSection = document.getElementById('stageDetailsSection');
+    if (detailsSection) {
+        detailsSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+}
+
 function initializeUploadModal() {
     const uploadDropZone = document.getElementById('uploadDropZone');
     const fileInput = document.getElementById('fileInput');
@@ -506,6 +527,13 @@ function updateStatusCards() {
     document.getElementById('processingCount').textContent = processingCount;
     document.getElementById('completedCount').textContent = completedCount;
     document.getElementById('errorCount').textContent = errorCount;
+
+    const errorCard = document.getElementById('errorStatusCard');
+    if (errorCard) {
+        errorCard.setAttribute('aria-disabled', errorCount === 0 ? 'true' : 'false');
+        errorCard.classList.toggle('has-count', errorCount > 0);
+        errorCard.classList.toggle('selected', selectedStage === 'error');
+    }
 }
 
 function updateStageFlow() {
@@ -804,6 +832,12 @@ function createSummaryContent(task) {
                     <strong>Error:</strong> ${escapeHtml(task.error_message)}
                 </div>
             ` : ''}
+            ${task.batches && task.batches.some(batch => Array.isArray(batch.warnings) && batch.warnings.length > 0) ? `
+                <div class="alert alert-warning mt-3">
+                    <i class="fas fa-info-circle me-2"></i>
+                    ${task.batches.filter(batch => Array.isArray(batch.warnings) && batch.warnings.length > 0).length} batch(es) returned warnings during LMM processing. Expand the batch details to review them.
+                </div>
+            ` : ''}
         </div>
     `;
 }
@@ -994,7 +1028,9 @@ function createBatchesContent(task) {
                                     onclick="selectBatch('${task.task_id}', '${batch.batch_id}', this)">
                                 <div class="d-flex justify-content-between align-items-center">
                                     <div>
-                                        <div class="fw-semibold">Batch ${batch.batch_number}</div>
+                                        <div class="fw-semibold">Batch ${batch.batch_number}
+                                            ${Array.isArray(batch.warnings) && batch.warnings.length > 0 ? '<span class="text-warning ms-2" title="This batch has warnings"><i class="fas fa-exclamation-circle"></i></span>' : ''}
+                                        </div>
                                         <small class="text-muted">Pages ${batch.start_page} - ${batch.end_page}</small>
                                     </div>
                                     <span class="badge bg-primary rounded-pill">${batch.page_count}</span>
@@ -1045,6 +1081,10 @@ function createChunkingContent(task) {
 
         const contextDetails = renderContextSnapshot(batch.context_snapshot);
 
+        const warningNotice = Array.isArray(batch.warnings) && batch.warnings.length > 0
+            ? `<div class="alert alert-warning"><strong>Heads up:</strong><br>${batch.warnings.map(msg => `<span class="d-block">${escapeHtml(msg)}</span>`).join('')}</div>`
+            : '';
+
         const lmmOutput = batch.lmm_output
             ? `<pre class="chunk-output">${escapeHtml(batch.lmm_output)}</pre>`
             : '<p class="text-muted mb-0">Output not available for this batch.</p>';
@@ -1064,6 +1104,7 @@ function createChunkingContent(task) {
                 </h2>
                 <div id="chunkCollapse-${batch.batch_id}" class="accordion-collapse collapse ${index === 0 ? 'show' : ''}" data-bs-parent="#${accordionId}">
                     <div class="accordion-body">
+                        ${warningNotice}
                         ${lmmOutput}
                         ${chunkSummary}
                         ${contextDetails}


### PR DESCRIPTION
## Summary
- handle OpenRouter authentication failures by falling back to mock output and returning structured warnings per batch
- propagate warning metadata through manual session payloads, processing manager batches, and the shared batch model
- surface warnings and error navigation in the human-in-the-loop and pipeline dashboards, including a clickable error card and inline alerts

## Testing
- python -m pytest *(fails: test_processor.py::test_local_pdf and test_splitter.py::test_splitter prompt for interactive input under pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68d4a71f0954832790fb156dce8635c7