### PR TITLE
Enable pipeline deep links from document history

### DIFF
--- a/main.py
+++ b/main.py
@@ -785,6 +785,7 @@ async def create_manual_batches(session_id: str, request: Request):
         prompt=default_prompt,
         model=processing_manager.lmm_processor.DEFAULT_MODEL,
         temperature=processing_manager.lmm_processor.temperature,
+        lifecycle_document_id=session.document_id,
     )
 
     manual_task.document.file_path = (
@@ -792,6 +793,8 @@ async def create_manual_batches(session_id: str, request: Request):
     )
     manual_task.document.source_type = "manual"
     metadata = dict(manual_task.document.metadata or {})
+    if session.document_id:
+        metadata.setdefault("document_id", session.document_id)
     metadata["processing_mode"] = "human_loop"
     metadata["overlap_pages"] = overlap_pages
     if session.display_name:

--- a/src/models/batch_models.py
+++ b/src/models/batch_models.py
@@ -115,6 +115,7 @@ class ProcessingTask:
     prompt: Optional[str] = None
     model: Optional[str] = None
     temperature: float = 0.1
+    lifecycle_document_id: Optional[str] = None
     context_state: Dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self):
@@ -166,6 +167,7 @@ class ProcessingTask:
             "prompt": self.prompt,
             "model": self.model,
             "temperature": self.temperature,
+            "lifecycle_document_id": self.lifecycle_document_id,
             "context_state": self.context_state
         }
 

--- a/src/processors/processing_manager.py
+++ b/src/processors/processing_manager.py
@@ -173,7 +173,8 @@ class ProcessingManager:
             status=ProcessingStage.UPLOAD,
             prompt=prompt,
             model=model or self.lmm_processor.DEFAULT_MODEL,
-            temperature=temperature if temperature is not None else self.lmm_processor.temperature
+            temperature=temperature if temperature is not None else self.lmm_processor.temperature,
+            lifecycle_document_id=lifecycle_document_id
         )
 
         with self._lock:
@@ -296,6 +297,13 @@ class ProcessingManager:
 
             # Update task with real document
             task.document = document
+            if lifecycle_document_id:
+                try:
+                    current_metadata = dict(task.document.metadata or {})
+                    current_metadata.setdefault("document_id", lifecycle_document_id)
+                    task.document.metadata = current_metadata
+                except Exception:
+                    logger.debug("Unable to merge lifecycle document metadata for task %s", task_id)
             task.model = model or self.lmm_processor.DEFAULT_MODEL
             task.prompt = prompt
             task.temperature = temperature if temperature is not None else self.lmm_processor.temperature

--- a/static/documents.js
+++ b/static/documents.js
@@ -108,21 +108,23 @@ function updateSummaryStats(documents) {
 }
 
 async function showDocumentDetails(documentId) {
+    redirectToPipeline(documentId);
+}
+
+function redirectToPipeline(documentId) {
+    if (!documentId) {
+        alert('Document identifier is missing for this record.');
+        return;
+    }
+
     try {
-        const response = await fetch(`/api/documents/${documentId}`);
-        if (!response.ok) {
-            throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-        }
-
-        const data = await response.json();
-        populateDocumentDetailModal(data);
-
-        const modal = new bootstrap.Modal(document.getElementById('documentDetailModal'));
-        modal.show();
-
+        const targetUrl = new URL('/pipeline', window.location.origin);
+        targetUrl.searchParams.set('documentId', documentId);
+        targetUrl.searchParams.set('view', 'fullscreen');
+        window.location.href = targetUrl.toString();
     } catch (error) {
-        console.error('Error loading document details:', error);
-        alert('Failed to load document details: ' + error.message);
+        console.error('Failed to redirect to pipeline view:', error);
+        alert('Unable to open the processing pipeline for this document.');
     }
 }
 

--- a/templates/documents.html
+++ b/templates/documents.html
@@ -881,17 +881,24 @@
         }
 
         function viewDocument(documentId) {
-            // Load document details and show modal
-            fetch(`/api/documents/${documentId}`)
-                .then(response => response.json())
-                .then(data => {
-                    populateDocumentDetails(data);
-                    showModal('documentDetailModal');
-                })
-                .catch(error => {
-                    console.error('Error loading document details:', error);
-                    alert('Failed to load document details');
-                });
+            navigateToPipeline(documentId);
+        }
+
+        function navigateToPipeline(documentId) {
+            if (!documentId) {
+                alert('Document identifier is missing for this record.');
+                return;
+            }
+
+            try {
+                const targetUrl = new URL('/pipeline', window.location.origin);
+                targetUrl.searchParams.set('documentId', documentId);
+                targetUrl.searchParams.set('view', 'fullscreen');
+                window.location.href = targetUrl.toString();
+            } catch (error) {
+                console.error('Failed to redirect to pipeline view:', error);
+                alert('Unable to open the processing pipeline for this document.');
+            }
         }
 
         function populateDocumentDetails(data) {

--- a/templates/pipeline_v2.html
+++ b/templates/pipeline_v2.html
@@ -317,6 +317,10 @@ let selectedStage = null;
 let selectedTaskId = null;
 let selectedFiles = [];
 let updateInterval = null;
+let pendingDocumentIdFromQuery = null;
+let pendingDocumentViewMode = 'auto';
+let pendingDocumentNavigationHandled = false;
+let pendingDocumentNavigationAttempts = 0;
 
 // Stage configuration
 const STAGES = {
@@ -333,8 +337,25 @@ const STAGES = {
 // Initialize dashboard
 document.addEventListener('DOMContentLoaded', function() {
     initializeUploadModal();
+    initializeQueryNavigation();
     startStatusUpdates();
 });
+
+function initializeQueryNavigation() {
+    try {
+        const params = new URLSearchParams(window.location.search);
+        const documentIdParam = params.get('documentId');
+        if (documentIdParam) {
+            pendingDocumentIdFromQuery = documentIdParam;
+            const viewParam = params.get('view');
+            if (viewParam) {
+                pendingDocumentViewMode = viewParam;
+            }
+        }
+    } catch (error) {
+        console.error('Failed to parse pipeline query parameters:', error);
+    }
+}
 
 function handleErrorStatusClick() {
     const errorCountEl = document.getElementById('errorCount');
@@ -528,6 +549,121 @@ function updateDashboard() {
             console.error('Error updating task output:', error);
         });
     }
+    handlePendingDocumentNavigation();
+}
+
+function handlePendingDocumentNavigation() {
+    if (!pendingDocumentIdFromQuery || pendingDocumentNavigationHandled) {
+        return;
+    }
+
+    const result = findTaskByDocumentId(pendingDocumentIdFromQuery);
+    if (!result) {
+        pendingDocumentNavigationAttempts += 1;
+        if (pendingDocumentNavigationAttempts > 5) {
+            showAlert(
+                `Unable to locate document ${pendingDocumentIdFromQuery} in the active pipeline list. It may have been cleared or is unavailable.`,
+                'warning'
+            );
+            pendingDocumentNavigationHandled = true;
+            clearQueryParamsAfterNavigation();
+        }
+        return;
+    }
+
+    pendingDocumentNavigationHandled = true;
+    pendingDocumentNavigationAttempts = 0;
+
+    const { taskId, task } = result;
+    const stageKey = getStageKeyForTask(task);
+
+    if (stageKey) {
+        selectStage(stageKey);
+        selectedTaskId = taskId;
+        updateStageDetails();
+    }
+
+    const openFullscreen = task?.status === 'completed' || pendingDocumentViewMode === 'fullscreen';
+
+    if (openFullscreen) {
+        setTimeout(() => {
+            openFullscreenView(taskId);
+            scrollStageDetailsIntoView();
+        }, 200);
+    } else {
+        updateTaskOutput().catch(error => {
+            console.error('Error updating task output during navigation:', error);
+        });
+        scrollStageDetailsIntoView();
+    }
+
+    clearQueryParamsAfterNavigation();
+}
+
+function findTaskByDocumentId(documentId) {
+    if (!documentId) {
+        return null;
+    }
+
+    const entries = Object.entries(allTasks || {});
+    for (const [taskId, task] of entries) {
+        if (!task) {
+            continue;
+        }
+
+        const lifecycleId = task.lifecycle_document_id
+            || task.document_info?.metadata?.document_id
+            || task.document_info?.metadata?.documentId;
+
+        if (lifecycleId && lifecycleId === documentId) {
+            return { taskId, task };
+        }
+    }
+
+    return null;
+}
+
+function getStageKeyForTask(task) {
+    if (!task) {
+        return null;
+    }
+
+    if (task.status === 'error') {
+        return 'error';
+    }
+
+    if (STAGES[task.status]) {
+        return task.status;
+    }
+
+    return 'completed';
+}
+
+function scrollStageDetailsIntoView() {
+    const detailsSection = document.getElementById('stageDetailsSection');
+    if (detailsSection) {
+        detailsSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+}
+
+function clearQueryParamsAfterNavigation() {
+    if (typeof window === 'undefined' || !window.history || !window.history.replaceState) {
+        pendingDocumentIdFromQuery = null;
+        pendingDocumentViewMode = 'auto';
+        return;
+    }
+
+    try {
+        const url = new URL(window.location.href);
+        url.searchParams.delete('documentId');
+        url.searchParams.delete('view');
+        window.history.replaceState({}, document.title, url.pathname + url.search + url.hash);
+    } catch (error) {
+        console.error('Failed to clear pipeline query parameters:', error);
+    }
+
+    pendingDocumentIdFromQuery = null;
+    pendingDocumentViewMode = 'auto';
 }
 
 function updateStatusCards() {

--- a/test_database_writer.py
+++ b/test_database_writer.py
@@ -45,7 +45,8 @@ def test_database_writer():
             document=test_document,
             config=SplitConfiguration(),
             status=None,
-            prompt="Test prompt"
+            prompt="Test prompt",
+            lifecycle_document_id=None
         )
 
         test_batch = PageBatch(


### PR DESCRIPTION
## Summary
- store the lifecycle document identifier on processing tasks and preserve it in task metadata
- update the document history UI to redirect "View" actions to the pipeline dashboard with deep links
- enhance the pipeline dashboard to read document-based query parameters and focus or open the matching task

## Testing
- pytest *(fails: interactive tests require stdin and halt under pytest capture)*

------
https://chatgpt.com/codex/tasks/task_e_68da9895c48c832790f2764d44a5d0a9